### PR TITLE
fix-type-issues

### DIFF
--- a/Table of Contents.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Table of Contents.sketchplugin/Contents/Sketch/script.cocoascript
@@ -171,8 +171,6 @@ function addTableOfContents(doc, plugin, page, artboards, numberArtboard, contex
           }
         });
 
-        textTitle.systemFontSize = 32;
-
 // var text = MSTextLayer.new();
 // text.setName("Table of Contents");
 // text.frame().setX(100);
@@ -254,9 +252,6 @@ function addTableOfContents(doc, plugin, page, artboards, numberArtboard, contex
             }
           });
 
-          text.systemFontSize = userInput.fsize;
-          ptext.systemFontSize = userInput.fsize;
-
           var p = "";
           if(page !== "") p = "Page "+page;
 
@@ -273,7 +268,6 @@ function addTableOfContents(doc, plugin, page, artboards, numberArtboard, contex
             }
           });
 
-          pnumber.systemFontSize = 16;
 
 //           if(l <= 1) ;
 //           else if(temp.children()[l-2].toString().split("Header")[1] == null) ;


### PR DESCRIPTION
Removed the text.systemfontsize API calls, they are deprecated, and they mess up the setting of font style in the previous lines of code.

Also, in newer Mac OS, systemfontsize results in a missing font alert in Sketch